### PR TITLE
Background image unaffected by keyboard

### DIFF
--- a/App.js
+++ b/App.js
@@ -102,9 +102,10 @@ const styles = StyleSheet.create({
 	},
 	background: {
 		position: "absolute",
+		zIndex: 0,
 		left: 0,
 		top: 0,
 		width: "200%",
-		height: "100%",
+		height: 900,
 	},
 });

--- a/App.js
+++ b/App.js
@@ -102,7 +102,6 @@ const styles = StyleSheet.create({
 	},
 	background: {
 		position: "absolute",
-		zIndex: 0,
 		left: 0,
 		top: 0,
 		width: "200%",

--- a/components/CityStateSelector.js
+++ b/components/CityStateSelector.js
@@ -74,6 +74,7 @@ const CityStateSelector = () => {
 				underlineColorAndroid: "transparent",
 				style: styles.textInputContainer,
 				onTextChange: (text) => console.log(text),
+				keyboardAppearance: "dark"
 			}}
 			listProps={{
 				nestedScrollEnabled: true,


### PR DESCRIPTION
<!--- Release Notes
Your one liner release notes here
--->
### Release Notes
```
Background image now unaffected by keyboard
Resolves #9 
```

### Pull request type
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Other: 

### Pull request size
- [x] Tiny
- [ ] Small
- [ ] Medium
- [ ] Large

#### Describe the old behavior you are changing
- Background image moves when keyboard opens on android
- 
- 

#### Describe the new behavior from this change
- Background image no longer moves on keyboard open
- 
- 
